### PR TITLE
feat: enhance metadata handling and improve configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,13 @@
 /** @type {import('next').NextConfig} */
+if (
+  process.env.NODE_ENV === "production" &&
+  !process.env.NEXT_PUBLIC_SITE_URL?.trim()
+) {
+  console.warn(
+    "[portfolio] NEXT_PUBLIC_SITE_URL is not set. Set it to your canonical HTTPS URL for stable canonical tags and social previews.",
+  );
+}
+
 const nextConfig = {
   transpilePackages: ["next-mdx-remote"],
   reactCompiler: true,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "portfolio",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "bun@1.3.12",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -6,7 +6,11 @@ import MainGrid, { MainGridFallback } from "@/components/MainGrid";
 import NavBar from "@/components/NavBar";
 
 import { getOwnerDataDTO } from "@/data/project-dto";
-import { getAbsoluteImageUrl, getCanonicalUrl } from "@/utils/metadata";
+import {
+  getAbsoluteImageUrl,
+  getCanonicalUrl,
+  getOwnerAvatarPath,
+} from "@/utils/metadata";
 
 export async function generateMetadata(): Promise<Metadata> {
   const ownerData = await getOwnerDataDTO();
@@ -14,7 +18,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const title = ownerName ? `${ownerName}'s Portfolio` : "Portfolio";
   const description = ownerData?.aboutMe || "";
   const homeUrl = getCanonicalUrl("");
-  const ogImage = getAbsoluteImageUrl(ownerData?.avatar || "/Avatar.webp");
+  const ogImage = getAbsoluteImageUrl(getOwnerAvatarPath(ownerData?.avatar));
 
   return {
     description,

--- a/src/app/(site)/project/[slug]/not-found.tsx
+++ b/src/app/(site)/project/[slug]/not-found.tsx
@@ -1,4 +1,5 @@
 import { ChevronLeftIcon, FrownIcon } from "lucide-react";
+import type { Metadata } from "next";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
@@ -10,6 +11,15 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+
+export const metadata: Metadata = {
+  title: "Project not found",
+  description: "The requested project does not exist or was removed.",
+  robots: {
+    index: false,
+    follow: true,
+  },
+};
 
 export default function NotFound() {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,28 +10,32 @@ import {
   getAbsoluteImageUrl,
   getCanonicalUrl,
   getMetadataBase,
+  getOwnerAvatarPath,
 } from "@/utils/metadata";
 
-export const metadata: Promise<Metadata> = (async () => {
+export async function generateMetadata(): Promise<Metadata> {
   const ownerData = await getOwnerDataDTO();
 
-  const title = ownerData?.name ? `${ownerData.name}'s Portfolio` : "";
+  const ownerName = ownerData?.name || "";
+  const brandTitle = ownerName ? `${ownerName}'s Portfolio` : "Portfolio";
   const description = ownerData?.aboutMe || "";
 
-  // Use owner's logo or fallback to default logo
-  const ogImage = getAbsoluteImageUrl("/Avatar.webp");
-
-  const ownerName = ownerData?.name || "";
+  const avatarPath = getOwnerAvatarPath(ownerData?.avatar);
+  const ogImage = getAbsoluteImageUrl(avatarPath);
 
   const homeUrl = getCanonicalUrl("");
 
   return {
     metadataBase: getMetadataBase(),
     title: {
-      default: title,
-      template: `${title} | %s`,
+      default: brandTitle,
+      template: `%s | ${brandTitle}`,
     },
     description,
+    icons: {
+      icon: avatarPath,
+      apple: avatarPath,
+    },
     keywords: [
       "web developer",
       "full-stack developer",
@@ -48,7 +52,7 @@ export const metadata: Promise<Metadata> = (async () => {
     ],
     authors: [{ name: ownerName }],
     creator: ownerName,
-    applicationName: `${ownerName}'s Portfolio`,
+    applicationName: brandTitle,
     category: "Portfolio",
     alternates: {
       canonical: homeUrl,
@@ -56,8 +60,8 @@ export const metadata: Promise<Metadata> = (async () => {
     openGraph: {
       type: "website",
       locale: "en_US",
-      siteName: `${ownerName}'s Portfolio`,
-      title,
+      siteName: brandTitle,
+      title: brandTitle,
       description,
       url: homeUrl,
       images: [
@@ -65,13 +69,13 @@ export const metadata: Promise<Metadata> = (async () => {
           url: ogImage,
           width: 1200,
           height: 630,
-          alt: title,
+          alt: brandTitle,
         },
       ],
     },
     twitter: {
       card: "summary_large_image",
-      title,
+      title: brandTitle,
       description,
       images: [ogImage],
     },
@@ -87,7 +91,7 @@ export const metadata: Promise<Metadata> = (async () => {
       },
     },
   };
-})();
+}
 
 export const viewport: Viewport = {
   width: "device-width",

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,6 +1,7 @@
 import { MetadataRoute } from "next";
 
 import { getOwnerDataDTO } from "@/data/project-dto";
+import { getOwnerAvatarPath } from "@/utils/metadata";
 
 export default async function manifest(): Promise<MetadataRoute.Manifest> {
   const ownerData = await getOwnerDataDTO();
@@ -16,7 +17,7 @@ export default async function manifest(): Promise<MetadataRoute.Manifest> {
     theme_color: "#000000",
     icons: [
       {
-        src: ownerData?.avatar || "/Avatar.webp",
+        src: getOwnerAvatarPath(ownerData?.avatar),
         sizes: "any",
         type: "image/webp",
       },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,7 +8,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const projectUrls = projects.map((slug) => ({
     url: getCanonicalUrl(`/project/${slug}`),
-    lastModified: new Date(),
     changeFrequency: "monthly" as const,
     priority: 0.8,
   }));
@@ -16,7 +15,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   return [
     {
       url: getCanonicalUrl(""),
-      lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 1,
     },

--- a/src/components/HomeJsonLd.tsx
+++ b/src/components/HomeJsonLd.tsx
@@ -1,23 +1,45 @@
-// src/components/JsonLd.tsx
 import { getOwnerData } from "@/server/owner";
-import { getAbsoluteImageUrl, getCanonicalUrl } from "@/utils/metadata";
+import {
+  getAbsoluteImageUrl,
+  getCanonicalUrl,
+  getOwnerAvatarPath,
+} from "@/utils/metadata";
 
 export default async function HomeJsonLd() {
   const ownerData = await getOwnerData();
   const ownerName = ownerData?.name || "Portfolio Owner";
   const homeUrl = getCanonicalUrl("");
-  const profileImage = getAbsoluteImageUrl("/Avatar.webp");
+  const brandName = ownerName ? `${ownerName}'s Portfolio` : "Portfolio";
+  const profileImage = getAbsoluteImageUrl(
+    getOwnerAvatarPath(ownerData?.avatar),
+  );
+
+  const personId = `${homeUrl}#person`;
+  const websiteId = `${homeUrl}#website`;
 
   const jsonLd = {
     "@context": "https://schema.org",
-    "@type": "Person",
-    name: ownerName,
-    description: ownerData?.aboutMe || `${ownerName}'s Portfolio`,
-    url: homeUrl,
-    image: profileImage,
-    ...(ownerData?.githubUser && {
-      sameAs: [`https://github.com/${ownerData.githubUser}`],
-    }),
+    "@graph": [
+      {
+        "@type": "Person",
+        "@id": personId,
+        name: ownerName,
+        description: ownerData?.aboutMe || brandName,
+        url: homeUrl,
+        image: profileImage,
+        ...(ownerData?.githubUser && {
+          sameAs: [`https://github.com/${ownerData.githubUser}`],
+        }),
+      },
+      {
+        "@type": "WebSite",
+        "@id": websiteId,
+        url: homeUrl,
+        name: brandName,
+        description: ownerData?.aboutMe || brandName,
+        publisher: { "@id": personId },
+      },
+    ],
   };
 
   return (

--- a/src/components/ProjectJsonLd.tsx
+++ b/src/components/ProjectJsonLd.tsx
@@ -7,8 +7,8 @@ export default async function ProjectJsonLd({ slug }: { slug: string }) {
   const ownerData = await getOwnerData();
 
   const ownerName = ownerData?.name || "Daniel";
+  const homeUrl = getCanonicalUrl("");
   const projectUrl = getCanonicalUrl(`/project/${slug}`);
-  // Ensure coverImage path has leading slash for consistency
   const coverImagePath = project.coverImage
     ? project.coverImage.startsWith("/")
       ? project.coverImage
@@ -16,23 +16,54 @@ export default async function ProjectJsonLd({ slug }: { slug: string }) {
     : "/Avatar.webp";
   const projectImage = getAbsoluteImageUrl(coverImagePath);
 
-  // JSON-LD structured data for SEO
+  const authorUrl = ownerData?.githubUser
+    ? `https://github.com/${ownerData.githubUser}`
+    : undefined;
+
   const jsonLd = {
     "@context": "https://schema.org",
-    "@type": "CreativeWork",
-    name: project.name,
-    description:
-      project.description || `${project.name} - A project by ${ownerName}`,
-    image: projectImage,
-    url: projectUrl,
-    author: {
-      "@type": "Person",
-      name: ownerName,
-    },
-    ...(project.status && {
-      creativeWorkStatus: project.status,
-    }),
+    "@graph": [
+      {
+        "@type": "CreativeWork",
+        "@id": `${projectUrl}#creativework`,
+        name: project.name,
+        description:
+          project.description || `${project.name} - A project by ${ownerName}`,
+        image: projectImage,
+        url: projectUrl,
+        mainEntityOfPage: {
+          "@type": "WebPage",
+          "@id": projectUrl,
+        },
+        author: {
+          "@type": "Person",
+          name: ownerName,
+          ...(authorUrl && { url: authorUrl }),
+        },
+        ...(project.status && {
+          creativeWorkStatus: project.status,
+        }),
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "Home",
+            item: homeUrl,
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: project.name,
+            item: projectUrl,
+          },
+        ],
+      },
+    ],
   };
+
   return (
     <script
       type="application/ld+json"

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -3,16 +3,21 @@
  */
 
 /**
- * Get the base URL for the site
- * Uses NEXT_PUBLIC_SITE_URL environment variable if available,
- * otherwise falls back to relative URLs
+ * Public avatar path for OG, icons, and JSON-LD (leading slash, under /public).
+ */
+export function getOwnerAvatarPath(
+  avatar: string | null | undefined,
+): string {
+  const raw = avatar || "/Avatar.webp";
+  return raw.startsWith("/") ? raw : `/${raw}`;
+}
+
+/**
+ * Canonical origin for absolute URLs (canonical tags, OG, JSON-LD).
+ * Matches {@link getMetadataBase} resolution so strings stay consistent with Next metadata.
  */
 export function getBaseUrl(): string {
-  if (process.env.NEXT_PUBLIC_SITE_URL) {
-    return process.env.NEXT_PUBLIC_SITE_URL;
-  }
-  // Fallback for development or when env var is not set
-  return "";
+  return getMetadataBase().origin;
 }
 
 /**
@@ -20,26 +25,18 @@ export function getBaseUrl(): string {
  * Social platforms require absolute URLs for images
  */
 export function getAbsoluteImageUrl(imagePath: string): string {
-  const baseUrl = getBaseUrl();
-  if (!baseUrl) {
-    // If no base URL, return the path as-is (Next.js will handle it)
-    return imagePath.startsWith("/") ? imagePath : `/${imagePath}`;
-  }
-  // Remove leading slash if baseUrl already ends with one or path starts with one
+  const baseUrl = getBaseUrl().replace(/\/$/, "");
   const cleanPath = imagePath.startsWith("/") ? imagePath : `/${imagePath}`;
-  return `${baseUrl.replace(/\/$/, "")}${cleanPath}`;
+  return `${baseUrl}${cleanPath}`;
 }
 
 /**
  * Generate a canonical URL for a given path
  */
 export function getCanonicalUrl(path: string = ""): string {
-  const baseUrl = getBaseUrl();
-  if (!baseUrl) {
-    return path.startsWith("/") ? path : `/${path}`;
-  }
+  const baseUrl = getBaseUrl().replace(/\/$/, "");
   const cleanPath = path.startsWith("/") ? path : `/${path}`;
-  return `${baseUrl.replace(/\/$/, "")}${cleanPath}`;
+  return `${baseUrl}${cleanPath}`;
 }
 
 /**


### PR DESCRIPTION
- Added a warning in next.config.js for missing NEXT_PUBLIC_SITE_URL in production.
- Updated package.json to specify bun as the package manager.
- Refactored metadata generation in layout.tsx and page.tsx to use a consistent brand title.
- Introduced getOwnerAvatarPath utility for consistent avatar path handling across components.
- Improved JSON-LD structured data in HomeJsonLd and ProjectJsonLd components for better SEO.
- Removed lastModified fields from sitemap entries for cleaner output.

Fixes #79