### PR TITLE
fix: remediate shadscan audit findings

### DIFF
--- a/src/app/project/[slug]/not-found.tsx
+++ b/src/app/project/[slug]/not-found.tsx
@@ -46,6 +46,7 @@ export default function NotFound() {
             nativeButton={false}
           >
             <ChevronLeftIcon className="size-6" aria-hidden />
+            <span className="sr-only">Go back to home</span>
           </Button>
         </CardFooter>
       </Card>

--- a/src/app/project/[slug]/not-found.tsx
+++ b/src/app/project/[slug]/not-found.tsx
@@ -36,11 +36,16 @@ export default function NotFound() {
           <Button
             variant="projectLink"
             size="icon-lg"
-            aria-label="Go back to home"
-            render={<Link href="/" transitionTypes={["nav-back"]} />}
+            render={
+              <Link
+                href="/"
+                transitionTypes={["nav-back"]}
+                aria-label="Go back to home"
+              />
+            }
             nativeButton={false}
           >
-            <ChevronLeftIcon className="size-6" />
+            <ChevronLeftIcon className="size-6" aria-hidden />
           </Button>
         </CardFooter>
       </Card>

--- a/src/components/GoBackButton.tsx
+++ b/src/components/GoBackButton.tsx
@@ -23,6 +23,7 @@ export default function GoBackButton() {
       nativeButton={false}
     >
       <XIcon className="size-6" aria-hidden />
+      <span className="sr-only">Go back to home</span>
     </Button>
   );
 }

--- a/src/components/GoBackButton.tsx
+++ b/src/components/GoBackButton.tsx
@@ -12,17 +12,17 @@ export default function GoBackButton() {
       size="icon-lg"
       type="button"
       className="cancelDrag"
-      aria-label="Go back to home"
       render={
         <Link
           href="/"
           transitionTypes={["nav-back"]}
+          aria-label="Go back to home"
           onClick={() => capture("back_to_home_clicked")}
         />
       }
       nativeButton={false}
     >
-      <XIcon className="size-6" />
+      <XIcon className="size-6" aria-hidden />
     </Button>
   );
 }

--- a/src/components/NavItems.tsx
+++ b/src/components/NavItems.tsx
@@ -8,6 +8,7 @@ import {
   type SubmitEvent,
 } from "react";
 
+import { Field, FieldError } from "@/components/ui/field";
 import { PillTabs } from "@/components/ui/pill-tabs";
 
 import {
@@ -110,7 +111,8 @@ export default function NavItemsClient({
     commitTab(parsed.data);
   }
 
-  const error = optimisticState.status === "error" ? optimisticState.error : null;
+  const error =
+    optimisticState.status === "error" ? optimisticState.error : null;
 
   return (
     <form
@@ -120,40 +122,38 @@ export default function NavItemsClient({
       aria-busy={isPending || undefined}
       data-pending={isPending || undefined}
     >
-      <PillTabs.Root
-        value={optimisticState.activeTab}
-        onValueChange={handleValueChange}
-      >
-        <PillTabs.List
-          size="default"
-          aria-label="Main grid views"
-          activateOnFocus
+      <Field data-invalid={error ? true : undefined} className="contents">
+        <PillTabs.Root
+          value={optimisticState.activeTab}
+          onValueChange={handleValueChange}
         >
-          {tabs.map((tabId) => (
-            <PillTabs.Item
-              key={tabId}
-              id={mainGridTabId(tabId)}
-              value={tabId}
-              aria-controls={MAIN_GRID_TABPANEL_ID}
-              render={
-                <button
-                  type="submit"
-                  name="tab"
-                  value={tabId}
-                  aria-labelledby={mainGridTabLabelId(tabId)}
-                />
-              }
-            >
-              <span id={mainGridTabLabelId(tabId)}>{tabId}</span>
-            </PillTabs.Item>
-          ))}
-        </PillTabs.List>
-      </PillTabs.Root>
-      {error ? (
-        <p role="alert" className="sr-only">
-          {error}
-        </p>
-      ) : null}
+          <PillTabs.List
+            size="default"
+            aria-label="Main grid views"
+            activateOnFocus
+          >
+            {tabs.map((tabId) => (
+              <PillTabs.Item
+                key={tabId}
+                id={mainGridTabId(tabId)}
+                value={tabId}
+                aria-controls={MAIN_GRID_TABPANEL_ID}
+                render={
+                  <button
+                    type="submit"
+                    name="tab"
+                    value={tabId}
+                    aria-labelledby={mainGridTabLabelId(tabId)}
+                  />
+                }
+              >
+                <span id={mainGridTabLabelId(tabId)}>{tabId}</span>
+              </PillTabs.Item>
+            ))}
+          </PillTabs.List>
+        </PillTabs.Root>
+        <FieldError className="sr-only">{error}</FieldError>
+      </Field>
     </form>
   );
 }

--- a/src/components/NavItems.tsx
+++ b/src/components/NavItems.tsx
@@ -8,7 +8,7 @@ import {
   type SubmitEvent,
 } from "react";
 
-import { Field, FieldError } from "@/components/ui/field";
+import { FieldError } from "@/components/ui/field";
 import { PillTabs } from "@/components/ui/pill-tabs";
 
 import {
@@ -122,38 +122,36 @@ export default function NavItemsClient({
       aria-busy={isPending || undefined}
       data-pending={isPending || undefined}
     >
-      <Field data-invalid={error ? true : undefined} className="contents">
-        <PillTabs.Root
-          value={optimisticState.activeTab}
-          onValueChange={handleValueChange}
+      <PillTabs.Root
+        value={optimisticState.activeTab}
+        onValueChange={handleValueChange}
+      >
+        <PillTabs.List
+          size="default"
+          aria-label="Main grid views"
+          activateOnFocus
         >
-          <PillTabs.List
-            size="default"
-            aria-label="Main grid views"
-            activateOnFocus
-          >
-            {tabs.map((tabId) => (
-              <PillTabs.Item
-                key={tabId}
-                id={mainGridTabId(tabId)}
-                value={tabId}
-                aria-controls={MAIN_GRID_TABPANEL_ID}
-                render={
-                  <button
-                    type="submit"
-                    name="tab"
-                    value={tabId}
-                    aria-labelledby={mainGridTabLabelId(tabId)}
-                  />
-                }
-              >
-                <span id={mainGridTabLabelId(tabId)}>{tabId}</span>
-              </PillTabs.Item>
-            ))}
-          </PillTabs.List>
-        </PillTabs.Root>
-        <FieldError className="sr-only">{error}</FieldError>
-      </Field>
+          {tabs.map((tabId) => (
+            <PillTabs.Item
+              key={tabId}
+              id={mainGridTabId(tabId)}
+              value={tabId}
+              aria-controls={MAIN_GRID_TABPANEL_ID}
+              render={
+                <button
+                  type="submit"
+                  name="tab"
+                  value={tabId}
+                  aria-labelledby={mainGridTabLabelId(tabId)}
+                />
+              }
+            >
+              <span id={mainGridTabLabelId(tabId)}>{tabId}</span>
+            </PillTabs.Item>
+          ))}
+        </PillTabs.List>
+      </PillTabs.Root>
+      <FieldError className="sr-only">{error}</FieldError>
     </form>
   );
 }

--- a/src/components/NavItems.tsx
+++ b/src/components/NavItems.tsx
@@ -5,7 +5,6 @@ import {
   useActionState,
   useOptimistic,
   useRef,
-  useState,
   type SubmitEvent,
 } from "react";
 
@@ -53,7 +52,6 @@ export default function NavItemsClient({
     state,
     (_current, next: MainGridTabFormState) => next,
   );
-  const [error, setError] = useState<string | null>(null);
   const skipSubmitForTab = useRef<TabsType | null>(null);
 
   function commitTab(tab: TabsType) {
@@ -63,10 +61,9 @@ export default function NavItemsClient({
 
     const formData = new FormData();
     formData.set("tab", tab);
-    const next: MainGridTabFormState = { activeTab: tab };
+    const next: MainGridTabFormState = { status: "ok", activeTab: tab };
 
     capture("grid_tab_switched", { tab });
-    setError(null);
 
     startTransition(() => {
       setOptimisticState(next);
@@ -78,7 +75,9 @@ export default function NavItemsClient({
     event.preventDefault();
     const tab = tabFromSubmit(event);
     if (!tab) {
-      setError("Choose a valid view tab.");
+      startTransition(() => {
+        formAction(formDataFromSubmit(event));
+      });
       return;
     }
     if (tab === optimisticState.activeTab) {
@@ -96,7 +95,11 @@ export default function NavItemsClient({
   function handleValueChange(value: string) {
     const parsed = tabsTypeSchema.safeParse(value);
     if (!parsed.success) {
-      setError("Choose a valid view tab.");
+      const formData = new FormData();
+      formData.set("tab", value);
+      startTransition(() => {
+        formAction(formData);
+      });
       return;
     }
     if (parsed.data === optimisticState.activeTab) {
@@ -106,6 +109,8 @@ export default function NavItemsClient({
     skipSubmitForTab.current = parsed.data;
     commitTab(parsed.data);
   }
+
+  const error = optimisticState.status === "error" ? optimisticState.error : null;
 
   return (
     <form

--- a/src/components/NavItems.tsx
+++ b/src/components/NavItems.tsx
@@ -5,6 +5,7 @@ import {
   useActionState,
   useOptimistic,
   useRef,
+  useState,
   type SubmitEvent,
 } from "react";
 
@@ -52,6 +53,7 @@ export default function NavItemsClient({
     state,
     (_current, next: MainGridTabFormState) => next,
   );
+  const [error, setError] = useState<string | null>(null);
   const skipSubmitForTab = useRef<TabsType | null>(null);
 
   function commitTab(tab: TabsType) {
@@ -64,6 +66,7 @@ export default function NavItemsClient({
     const next: MainGridTabFormState = { activeTab: tab };
 
     capture("grid_tab_switched", { tab });
+    setError(null);
 
     startTransition(() => {
       setOptimisticState(next);
@@ -74,7 +77,11 @@ export default function NavItemsClient({
   function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
     const tab = tabFromSubmit(event);
-    if (!tab || tab === optimisticState.activeTab) {
+    if (!tab) {
+      setError("Choose a valid view tab.");
+      return;
+    }
+    if (tab === optimisticState.activeTab) {
       return;
     }
 
@@ -88,7 +95,11 @@ export default function NavItemsClient({
 
   function handleValueChange(value: string) {
     const parsed = tabsTypeSchema.safeParse(value);
-    if (!parsed.success || parsed.data === optimisticState.activeTab) {
+    if (!parsed.success) {
+      setError("Choose a valid view tab.");
+      return;
+    }
+    if (parsed.data === optimisticState.activeTab) {
       return;
     }
 
@@ -133,6 +144,11 @@ export default function NavItemsClient({
           ))}
         </PillTabs.List>
       </PillTabs.Root>
+      {error ? (
+        <p role="alert" className="sr-only">
+          {error}
+        </p>
+      ) : null}
     </form>
   );
 }

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -4,6 +4,13 @@ import {
   ThemeProviderProps,
 } from "next-themes";
 
+import { ThemeHotkey } from "@/components/ThemeHotkey";
+
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+  return (
+    <NextThemesProvider {...props}>
+      <ThemeHotkey />
+      {children}
+    </NextThemesProvider>
+  );
 }

--- a/src/components/ThemeHotkey.tsx
+++ b/src/components/ThemeHotkey.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect } from "react";
+
+import { capture } from "@/lib/analytics";
+
+function isTypingTarget(target: EventTarget | null) {
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    (target instanceof HTMLElement && target.isContentEditable)
+  );
+}
+
+export function ThemeHotkey() {
+  const { resolvedTheme, setTheme } = useTheme();
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (isTypingTarget(event.target)) {
+        return;
+      }
+
+      if (event.key.toLowerCase() !== "d") {
+        return;
+      }
+
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+
+      event.preventDefault();
+      const nextTheme = resolvedTheme === "dark" ? "light" : "dark";
+      setTheme(nextTheme);
+      capture("theme_selected", { theme: nextTheme });
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [resolvedTheme, setTheme]);
+
+  return null;
+}

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -22,7 +22,9 @@ export function NavBar({
       <Button
         variant="link"
         className="hidden text-xl/6 sm:block"
-        render={<Link href={`mailto:${contactEmail}`} />}
+        render={
+          <Link href={`mailto:${contactEmail}`} aria-label="Contact" />
+        }
         nativeButton={false}
       >
         Contact

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useMemo } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-6 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "mb-3 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const fieldVariants = cva(
+  "group/field flex w-full gap-3 data-[invalid=true]:text-destructive",
+  {
+    variants: {
+      orientation: {
+        vertical: "flex-col *:w-full [&>.sr-only]:w-auto",
+        horizontal:
+          "flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        responsive:
+          "flex-col *:w-full @md/field-group:flex-row @md/field-group:items-center @md/field-group:*:w-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:*:data-[slot=field-label]:flex-auto [&>.sr-only]:w-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+      },
+    },
+    defaultVariants: {
+      orientation: "vertical",
+    },
+  },
+);
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  );
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        "group/field-content flex flex-1 flex-col gap-1 leading-snug",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border *:data-[slot=field]:p-3 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        "text-left text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
+        "last:mt-0 nth-last-2:-mt-1",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  children?: React.ReactNode;
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn(
+        "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+        className,
+      )}
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>;
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children;
+    }
+
+    if (!errors?.length) {
+      return null;
+    }
+
+    const uniqueErrors = Array.from(
+      new Map(errors.map((error) => [error?.message, error])).values(),
+    );
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message;
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map(
+          (error, index) =>
+            error?.message && <li key={index}>{error.message}</li>,
+        )}
+      </ul>
+    );
+  }, [children, errors]);
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-sm font-normal text-destructive", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  );
+}
+
+export {
+  Field,
+  FieldLabel,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldContent,
+  FieldTitle,
+};

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
+
+import { cn } from "@/lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/src/features/contributions/components/parts/month-calendar.tsx
+++ b/src/features/contributions/components/parts/month-calendar.tsx
@@ -7,7 +7,6 @@ import {
   startTransition,
   useActionState,
   useOptimistic,
-  useState,
   type SubmitEvent,
 } from "react";
 
@@ -47,7 +46,6 @@ export function ContributionsMonthCalendar({
     state,
     (_current, next: ContributionsMonthFormState) => next,
   );
-  const [error, setError] = useState<string | null>(null);
   const { setOptimisticMonth } = useContributionsBoundary();
 
   function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
@@ -57,7 +55,9 @@ export function ContributionsMonthCalendar({
       formData.get("intent"),
     );
     if (!parsed.success) {
-      setError("Choose a valid month direction.");
+      startTransition(() => {
+        formAction(formData);
+      });
       return;
     }
 
@@ -68,7 +68,9 @@ export function ContributionsMonthCalendar({
       journeyStartAt,
     );
     if (!next) {
-      setError("That month is outside the available range.");
+      startTransition(() => {
+        formAction(formData);
+      });
       return;
     }
 
@@ -77,7 +79,6 @@ export function ContributionsMonthCalendar({
       month: next.month,
       direction: intent,
     });
-    setError(null);
 
     startTransition(() => {
       addTransitionType(intent === "next" ? "nav-forward" : "nav-back");
@@ -88,6 +89,7 @@ export function ContributionsMonthCalendar({
   }
 
   const { year, month, caption, canGoPrev, canGoNext } = optimisticState;
+  const error = optimisticState.status === "error" ? optimisticState.error : null;
 
   const monthStart = getMonthStartInZone(year, month, CONTRIBUTIONS_TZ);
   const monthShort = formatInTimeZone(monthStart, CONTRIBUTIONS_TZ, "MMM");

--- a/src/features/contributions/components/parts/month-calendar.tsx
+++ b/src/features/contributions/components/parts/month-calendar.tsx
@@ -12,7 +12,7 @@ import {
 
 import { useContributionsBoundary } from "@/features/contributions/components/parts/boundary";
 import { Button } from "@/components/ui/button";
-import { Field, FieldError } from "@/components/ui/field";
+import { FieldError } from "@/components/ui/field";
 import { capture } from "@/lib/analytics";
 
 import { changeContributionsMonthFormAction } from "@/features/contributions/contributions-actions";
@@ -107,53 +107,51 @@ export function ContributionsMonthCalendar({
       data-pending={isPending || undefined}
       className="cancelDrag group/calendar flex h-10 items-center rounded-full bg-input px-1"
     >
-      <Field data-invalid={error ? true : undefined} className="contents">
-        <Button
-          type="submit"
-          name="intent"
-          value="prev"
-          variant="ghost"
-          size="icon"
-          disabled={!canGoPrev}
-          aria-label="Go to the previous month"
-          className="size-8.5 transition-[transform,opacity,box-shadow,filter]"
+      <Button
+        type="submit"
+        name="intent"
+        value="prev"
+        variant="ghost"
+        size="icon"
+        disabled={!canGoPrev}
+        aria-label="Go to the previous month"
+        className="size-8.5 transition-[transform,opacity,box-shadow,filter]"
+      >
+        <ChevronLeftIcon className="size-5" aria-hidden="true" />
+      </Button>
+      <div role="status" aria-live="polite" aria-atomic="true">
+        <span className="sr-only">{caption}</span>
+        <time
+          dateTime={monthIso}
+          aria-hidden="true"
+          className="hidden text-sm leading-4 font-medium whitespace-nowrap select-none xl:inline"
         >
-          <ChevronLeftIcon className="size-5" aria-hidden="true" />
-        </Button>
-        <div role="status" aria-live="polite" aria-atomic="true">
-          <span className="sr-only">{caption}</span>
-          <time
-            dateTime={monthIso}
-            aria-hidden="true"
-            className="hidden text-sm leading-4 font-medium whitespace-nowrap select-none xl:inline"
-          >
-            {caption}
-          </time>
-          <time
-            dateTime={monthIso}
-            aria-hidden="true"
-            className="flex flex-col items-center justify-center leading-none select-none xl:hidden"
-          >
-            <span className="text-sm font-medium">{monthShort}</span>
-            <span className="text-[10px] font-medium tabular-nums">
-              {yearLabel}
-            </span>
-          </time>
-        </div>
-        <Button
-          type="submit"
-          name="intent"
-          value="next"
-          variant="ghost"
-          size="icon"
-          disabled={!canGoNext}
-          aria-label="Go to the next month"
-          className="size-8.5 transition-[transform,opacity,box-shadow,filter]"
+          {caption}
+        </time>
+        <time
+          dateTime={monthIso}
+          aria-hidden="true"
+          className="flex flex-col items-center justify-center leading-none select-none xl:hidden"
         >
-          <ChevronRightIcon className="size-5" aria-hidden="true" />
-        </Button>
-        <FieldError className="sr-only">{error}</FieldError>
-      </Field>
+          <span className="text-sm font-medium">{monthShort}</span>
+          <span className="text-[10px] font-medium tabular-nums">
+            {yearLabel}
+          </span>
+        </time>
+      </div>
+      <Button
+        type="submit"
+        name="intent"
+        value="next"
+        variant="ghost"
+        size="icon"
+        disabled={!canGoNext}
+        aria-label="Go to the next month"
+        className="size-8.5 transition-[transform,opacity,box-shadow,filter]"
+      >
+        <ChevronRightIcon className="size-5" aria-hidden="true" />
+      </Button>
+      <FieldError className="sr-only">{error}</FieldError>
     </form>
   );
 }

--- a/src/features/contributions/components/parts/month-calendar.tsx
+++ b/src/features/contributions/components/parts/month-calendar.tsx
@@ -12,6 +12,7 @@ import {
 
 import { useContributionsBoundary } from "@/features/contributions/components/parts/boundary";
 import { Button } from "@/components/ui/button";
+import { Field, FieldError } from "@/components/ui/field";
 import { capture } from "@/lib/analytics";
 
 import { changeContributionsMonthFormAction } from "@/features/contributions/contributions-actions";
@@ -89,7 +90,8 @@ export function ContributionsMonthCalendar({
   }
 
   const { year, month, caption, canGoPrev, canGoNext } = optimisticState;
-  const error = optimisticState.status === "error" ? optimisticState.error : null;
+  const error =
+    optimisticState.status === "error" ? optimisticState.error : null;
 
   const monthStart = getMonthStartInZone(year, month, CONTRIBUTIONS_TZ);
   const monthShort = formatInTimeZone(monthStart, CONTRIBUTIONS_TZ, "MMM");
@@ -105,55 +107,53 @@ export function ContributionsMonthCalendar({
       data-pending={isPending || undefined}
       className="cancelDrag group/calendar flex h-10 items-center rounded-full bg-input px-1"
     >
-      <Button
-        type="submit"
-        name="intent"
-        value="prev"
-        variant="ghost"
-        size="icon"
-        disabled={!canGoPrev}
-        aria-label="Go to the previous month"
-        className="size-8.5 transition-[transform,opacity,box-shadow,filter]"
-      >
-        <ChevronLeftIcon className="size-5" aria-hidden="true" />
-      </Button>
-      <div role="status" aria-live="polite" aria-atomic="true">
-        <span className="sr-only">{caption}</span>
-        <time
-          dateTime={monthIso}
-          aria-hidden="true"
-          className="hidden text-sm leading-4 font-medium whitespace-nowrap select-none xl:inline"
+      <Field data-invalid={error ? true : undefined} className="contents">
+        <Button
+          type="submit"
+          name="intent"
+          value="prev"
+          variant="ghost"
+          size="icon"
+          disabled={!canGoPrev}
+          aria-label="Go to the previous month"
+          className="size-8.5 transition-[transform,opacity,box-shadow,filter]"
         >
-          {caption}
-        </time>
-        <time
-          dateTime={monthIso}
-          aria-hidden="true"
-          className="flex flex-col items-center justify-center leading-none select-none xl:hidden"
+          <ChevronLeftIcon className="size-5" aria-hidden="true" />
+        </Button>
+        <div role="status" aria-live="polite" aria-atomic="true">
+          <span className="sr-only">{caption}</span>
+          <time
+            dateTime={monthIso}
+            aria-hidden="true"
+            className="hidden text-sm leading-4 font-medium whitespace-nowrap select-none xl:inline"
+          >
+            {caption}
+          </time>
+          <time
+            dateTime={monthIso}
+            aria-hidden="true"
+            className="flex flex-col items-center justify-center leading-none select-none xl:hidden"
+          >
+            <span className="text-sm font-medium">{monthShort}</span>
+            <span className="text-[10px] font-medium tabular-nums">
+              {yearLabel}
+            </span>
+          </time>
+        </div>
+        <Button
+          type="submit"
+          name="intent"
+          value="next"
+          variant="ghost"
+          size="icon"
+          disabled={!canGoNext}
+          aria-label="Go to the next month"
+          className="size-8.5 transition-[transform,opacity,box-shadow,filter]"
         >
-          <span className="text-sm font-medium">{monthShort}</span>
-          <span className="text-[10px] font-medium tabular-nums">
-            {yearLabel}
-          </span>
-        </time>
-      </div>
-      <Button
-        type="submit"
-        name="intent"
-        value="next"
-        variant="ghost"
-        size="icon"
-        disabled={!canGoNext}
-        aria-label="Go to the next month"
-        className="size-8.5 transition-[transform,opacity,box-shadow,filter]"
-      >
-        <ChevronRightIcon className="size-5" aria-hidden="true" />
-      </Button>
-      {error ? (
-        <p role="alert" className="sr-only">
-          {error}
-        </p>
-      ) : null}
+          <ChevronRightIcon className="size-5" aria-hidden="true" />
+        </Button>
+        <FieldError className="sr-only">{error}</FieldError>
+      </Field>
     </form>
   );
 }

--- a/src/features/contributions/components/parts/month-calendar.tsx
+++ b/src/features/contributions/components/parts/month-calendar.tsx
@@ -7,6 +7,7 @@ import {
   startTransition,
   useActionState,
   useOptimistic,
+  useState,
   type SubmitEvent,
 } from "react";
 
@@ -20,6 +21,7 @@ import {
   stepContributionsMonthFormState,
   type ContributionsMonthFormState,
 } from "@/features/contributions/lib/contributions-month";
+import { contributionsMonthIntentSchema } from "@/lib/schemas/contributions-month";
 import { CONTRIBUTIONS_TZ } from "@/lib/site/constants";
 
 function formDataFromSubmit(event: SubmitEvent<HTMLFormElement>): FormData {
@@ -45,26 +47,37 @@ export function ContributionsMonthCalendar({
     state,
     (_current, next: ContributionsMonthFormState) => next,
   );
+  const [error, setError] = useState<string | null>(null);
   const { setOptimisticMonth } = useContributionsBoundary();
 
   function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
     const formData = formDataFromSubmit(event);
-    const intent = formData.get("intent");
-    if (intent !== "prev" && intent !== "next") return;
+    const parsed = contributionsMonthIntentSchema.safeParse(
+      formData.get("intent"),
+    );
+    if (!parsed.success) {
+      setError("Choose a valid month direction.");
+      return;
+    }
 
+    const intent = parsed.data;
     const next = stepContributionsMonthFormState(
       optimisticState,
       intent,
       journeyStartAt,
     );
-    if (!next) return;
+    if (!next) {
+      setError("That month is outside the available range.");
+      return;
+    }
 
     capture("contributions_month_changed", {
       year: next.year,
       month: next.month,
       direction: intent,
     });
+    setError(null);
 
     startTransition(() => {
       addTransitionType(intent === "next" ? "nav-forward" : "nav-back");
@@ -134,6 +147,11 @@ export function ContributionsMonthCalendar({
       >
         <ChevronRightIcon className="size-5" aria-hidden="true" />
       </Button>
+      {error ? (
+        <p role="alert" className="sr-only">
+          {error}
+        </p>
+      ) : null}
     </form>
   );
 }

--- a/src/features/contributions/contributions-actions.ts
+++ b/src/features/contributions/contributions-actions.ts
@@ -7,6 +7,7 @@ import { getOwnerData } from "@/features/owner/owner-queries";
 import {
   buildContributionsMonthSnapshot,
   contributionsMonthCacheTag,
+  contributionsMonthFormError,
   formatContributionsMonthCookie,
   isCurrentContributionsMonth,
   stepContributionsMonthFormState,
@@ -72,7 +73,10 @@ export async function changeContributionsMonthFormAction(
 ): Promise<ContributionsMonthFormState> {
   const parsed = contributionsMonthIntentSchema.safeParse(formData.get("intent"));
   if (!parsed.success) {
-    return prevState;
+    return contributionsMonthFormError(
+      prevState,
+      "Choose a valid month direction.",
+    );
   }
 
   const owner = getOwnerData();
@@ -82,7 +86,10 @@ export async function changeContributionsMonthFormAction(
     owner.journeyStartAt,
   );
   if (!nextState) {
-    return prevState;
+    return contributionsMonthFormError(
+      prevState,
+      "That month is outside the available range.",
+    );
   }
 
   await changeContributionsMonth({

--- a/src/features/contributions/contributions-actions.ts
+++ b/src/features/contributions/contributions-actions.ts
@@ -12,6 +12,7 @@ import {
   stepContributionsMonthFormState,
   type ContributionsMonthFormState,
 } from "@/features/contributions/lib/contributions-month";
+import { contributionsMonthIntentSchema } from "@/lib/schemas/contributions-month";
 import {
   CONTRIBUTIONS_MONTH_COOKIE_KEY,
   CONTRIBUTIONS_TZ,
@@ -69,15 +70,15 @@ export async function changeContributionsMonthFormAction(
   prevState: ContributionsMonthFormState,
   formData: FormData,
 ): Promise<ContributionsMonthFormState> {
-  const intent = formData.get("intent");
-  if (intent !== "prev" && intent !== "next") {
+  const parsed = contributionsMonthIntentSchema.safeParse(formData.get("intent"));
+  if (!parsed.success) {
     return prevState;
   }
 
   const owner = getOwnerData();
   const nextState = stepContributionsMonthFormState(
     prevState,
-    intent,
+    parsed.data,
     owner.journeyStartAt,
   );
   if (!nextState) {

--- a/src/features/contributions/lib/contributions-month.test.ts
+++ b/src/features/contributions/lib/contributions-month.test.ts
@@ -216,6 +216,7 @@ describe("buildContributionsMonthFormState", () => {
       now,
     );
     expect(state).toEqual({
+      status: "ok",
       year: 2024,
       month: 3,
       caption: "Mar 2024",
@@ -232,6 +233,7 @@ describe("buildContributionsMonthFormState", () => {
       CONTRIBUTIONS_TZ,
       now,
     );
+    expect(state.status).toBe("ok");
     expect(state.canGoPrev).toBe(false);
     expect(state.canGoNext).toBe(true);
   });
@@ -244,6 +246,7 @@ describe("buildContributionsMonthFormState", () => {
       CONTRIBUTIONS_TZ,
       now,
     );
+    expect(state.status).toBe("ok");
     expect(state.canGoPrev).toBe(true);
     expect(state.canGoNext).toBe(false);
   });
@@ -263,6 +266,7 @@ describe("buildContributionsMonthFormState", () => {
       now,
     );
     expect(next).toEqual({
+      status: "ok",
       year: 2024,
       month: 4,
       caption: "Apr 2024",

--- a/src/features/contributions/lib/contributions-month.ts
+++ b/src/features/contributions/lib/contributions-month.ts
@@ -174,13 +174,32 @@ export function contributionsMonthCacheKey(
   return `${year}-${month}-${timeZone}`;
 }
 
-export type ContributionsMonthFormState = {
+type ContributionsMonthFormFields = {
   year: number;
   month: number;
   caption: string;
   canGoPrev: boolean;
   canGoNext: boolean;
 };
+
+export type ContributionsMonthFormState =
+  | (ContributionsMonthFormFields & { status: "ok" })
+  | (ContributionsMonthFormFields & { status: "error"; error: string });
+
+export function contributionsMonthFormError(
+  prevState: ContributionsMonthFormState,
+  error: string,
+): ContributionsMonthFormState {
+  return {
+    status: "error",
+    year: prevState.year,
+    month: prevState.month,
+    caption: prevState.caption,
+    canGoPrev: prevState.canGoPrev,
+    canGoNext: prevState.canGoNext,
+    error,
+  };
+}
 
 export function stepContributionsMonthFormState(
   prevState: ContributionsMonthFormState,
@@ -230,6 +249,7 @@ export function buildContributionsMonthFormState(
   const end = startOfMonth(calendarEndMonth);
 
   return {
+    status: "ok",
     year,
     month,
     caption: formatInTimeZone(current, timeZone, "MMM yyyy"),

--- a/src/features/home/components/nav-items.tsx
+++ b/src/features/home/components/nav-items.tsx
@@ -7,6 +7,7 @@ import { getActiveTab } from "@/lib/site/tabs";
 export async function NavItems() {
   const cookieStore = await cookies();
   const initialState: MainGridTabFormState = {
+    status: "ok",
     activeTab: getActiveTab(cookieStore),
   };
 

--- a/src/features/home/home-actions.ts
+++ b/src/features/home/home-actions.ts
@@ -75,9 +75,9 @@ async function switchMainGridTab(
   });
 }
 
-export type MainGridTabFormState = {
-  activeTab: TabsType;
-};
+export type MainGridTabFormState =
+  | { status: "ok"; activeTab: TabsType }
+  | { status: "error"; activeTab: TabsType; error: string };
 
 export async function switchMainGridTabFormAction(
   prevState: MainGridTabFormState,
@@ -85,16 +85,20 @@ export async function switchMainGridTabFormAction(
 ): Promise<MainGridTabFormState> {
   const parsed = tabsTypeSchema.safeParse(formData.get("tab"));
   if (!parsed.success) {
-    return prevState;
+    return {
+      status: "error",
+      activeTab: prevState.activeTab,
+      error: "Choose a valid view tab.",
+    };
   }
 
   const tab = parsed.data;
   if (tab === prevState.activeTab) {
-    return prevState;
+    return { status: "ok", activeTab: tab };
   }
 
   const projectSlugs = await getProjectSlugs();
   await switchMainGridTab(tab, projectSlugs);
 
-  return { activeTab: tab };
+  return { status: "ok", activeTab: tab };
 }

--- a/src/features/projects/components/mdx-remote.tsx
+++ b/src/features/projects/components/mdx-remote.tsx
@@ -45,23 +45,28 @@ const components: MDXComponents = {
   h4: (props) => <Heading level="h4" {...props} />,
   h5: (props) => <Heading level="h5" {...props} />,
   h6: (props) => <Heading level="h6" {...props} />,
-  a: ({ ...props }) => {
-    const href = props.href;
-
+  a: ({ children, href, ...props }) => {
     if (href?.startsWith("/")) {
-      const url = new URL(href);
       return (
-        <Link href={url} {...props}>
-          {props.children}
+        <Link href={href} {...props}>
+          {children}
         </Link>
       );
     }
 
     if (href?.startsWith("#")) {
-      return <a {...props} />;
+      return (
+        <a href={href} {...props}>
+          {children}
+        </a>
+      );
     }
 
-    return <a target="_blank" rel="noopener noreferrer" {...props} />;
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
+        {children}
+      </a>
+    );
   },
   code: ({ children, ...props }) => {
     const codeHTML = highlight(children?.toString());

--- a/src/features/projects/components/project-card-chrome.tsx
+++ b/src/features/projects/components/project-card-chrome.tsx
@@ -30,6 +30,7 @@ export default function ProjectCardChrome({
               href={`/project/${project.slug}`}
               prefetch={true}
               transitionTypes={["nav-forward"]}
+              aria-label={project.name}
               onClick={() =>
                 capture("project_card_clicked", {
                   project_slug: project.slug,

--- a/src/features/projects/components/project-card-chrome.tsx
+++ b/src/features/projects/components/project-card-chrome.tsx
@@ -51,7 +51,7 @@ export default function ProjectCardChrome({
               {project.name}
             </p>
           </ViewTransition>
-          <ArrowUpRightIcon className="absolute right-2 size-5" />
+          <ArrowUpRightIcon data-icon="inline-end" className="absolute right-2 size-5" />
         </Button>
       </div>
     </CardGrayscale>

--- a/src/lib/schemas/contributions-month.ts
+++ b/src/lib/schemas/contributions-month.ts
@@ -20,3 +20,9 @@ export const contributionsMonthCookieSchema =
 export type ContributionsYearMonth = z.infer<
   typeof contributionsMonthCookieSchema
 >;
+
+export const contributionsMonthIntentSchema = z.enum(["prev", "next"]);
+
+export type ContributionsMonthIntent = z.infer<
+  typeof contributionsMonthIntentSchema
+>;

--- a/src/lib/schemas/contributions-month.ts
+++ b/src/lib/schemas/contributions-month.ts
@@ -22,7 +22,3 @@ export type ContributionsYearMonth = z.infer<
 >;
 
 export const contributionsMonthIntentSchema = z.enum(["prev", "next"]);
-
-export type ContributionsMonthIntent = z.infer<
-  typeof contributionsMonthIntentSchema
->;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Surface field validation errors with shadcn `FieldError` on nav tab and contributions month forms; wire month intent via zod `safeParse` and `ok`/`error` `useActionState` variants.
- Give icon/render-prop Links accessible names (not-found, go-back, Contact, project cards) and render MDX anchor children explicitly.
- Add a guarded `d` theme hotkey under `ThemeProvider` (ignores input/textarea/select/contenteditable).
- Add `data-icon="inline-end"` on project card chrome arrow.

## Product decisions (waived)
- **Command menu**: too few destinations for a personal portfolio; no Cmd/Ctrl+K palette.
- **Toast provider**: no transient feedback flows; keep inline/Empty/error UX.
- **Mobile nav Sheet**: always-visible stacked header is sufficient.
- **Async pending disable**: optimistic tab/month updates must stay interactive; keep `aria-busy` without `disabled={isPending}`.

## Result
- Baseline: **65 / D** → after: **80 / B** (`bunx @shadscan/cli@0.8.0 --json`)
- Local gates + CI quality green; Vercel preview ready
- Month calendar layout fixed (no Field wrapper; `FieldError` only)

## Preview
- https://portfolio-git-cursor-cloud-agent-1785698-2f632c-daniellp99-team.vercel.app

## Test plan
- [x] Shadscan remediations + waived findings documented
- [x] Month calendar pill layout verified after FieldError change
- [x] Final review / bugbot clean before merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-427f02ff-7fa6-4bae-8ca3-6532d7745a39?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-427f02ff-7fa6-4bae-8ca3-6532d7745a39&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

