### PR TITLE
Two-state theme toggle with Verou system storage

### DIFF
--- a/src/components/ThemeHotkey.tsx
+++ b/src/components/ThemeHotkey.tsx
@@ -3,6 +3,10 @@
 import { useTheme } from "next-themes";
 import { useEffect } from "react";
 
+import {
+  type ColorScheme,
+  nextThemePreference,
+} from "@/components/theme-preference";
 import { capture } from "@/lib/analytics";
 
 function isTypingTarget(target: EventTarget | null) {
@@ -15,7 +19,7 @@ function isTypingTarget(target: EventTarget | null) {
 }
 
 export function ThemeHotkey() {
-  const { resolvedTheme, setTheme } = useTheme();
+  const { resolvedTheme, systemTheme, setTheme } = useTheme();
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
@@ -32,14 +36,17 @@ export function ThemeHotkey() {
       }
 
       event.preventDefault();
-      const nextTheme = resolvedTheme === "dark" ? "light" : "dark";
+      const resolved: ColorScheme =
+        resolvedTheme === "dark" ? "dark" : "light";
+      const system: ColorScheme = systemTheme === "dark" ? "dark" : "light";
+      const nextTheme = nextThemePreference(resolved, system);
       setTheme(nextTheme);
       capture("theme_selected", { theme: nextTheme });
     }
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [resolvedTheme, setTheme]);
+  }, [resolvedTheme, systemTheme, setTheme]);
 
   return null;
 }

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,23 +1,26 @@
 "use client";
 
-import { MonitorIcon, MoonIcon, SunIcon } from "lucide-react";
+import { MoonIcon, SunIcon } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 
+import {
+  type ColorScheme,
+  themePreferenceForScheme,
+} from "@/components/theme-preference";
 import { PillTabs } from "@/components/ui/pill-tabs";
 import { Skeleton } from "@/components/ui/skeleton";
 
 import { capture } from "@/lib/analytics";
 
-const THEME_OPTIONS = ["light", "system", "dark"] as const;
-type ThemeOption = (typeof THEME_OPTIONS)[number];
+const SCHEME_OPTIONS = ["light", "dark"] as const;
 
-function isThemeOption(value: string): value is ThemeOption {
-  return (THEME_OPTIONS as readonly string[]).includes(value);
+function isColorScheme(value: string): value is ColorScheme {
+  return (SCHEME_OPTIONS as readonly string[]).includes(value);
 }
 
 export default function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, systemTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -29,30 +32,33 @@ export default function ThemeToggle() {
   if (!mounted) {
     return (
       <div className="flex size-full items-center justify-center">
-        <Skeleton className="cancelDrag h-10 w-full max-w-[calc(--spacing(10)*3+4px)] rounded-full" />
+        <Skeleton className="cancelDrag h-10 w-full max-w-[calc(--spacing(10)*2+4px)] rounded-full" />
       </div>
     );
   }
 
+  const activeScheme: ColorScheme =
+    resolvedTheme === "dark" ? "dark" : "light";
+  const systemScheme: ColorScheme =
+    systemTheme === "dark" ? "dark" : "light";
+
   return (
     <div className="flex size-full items-center justify-center">
       <PillTabs.Root
-        value={theme ?? "system"}
+        value={activeScheme}
         onValueChange={(value) => {
-          if (!isThemeOption(value)) {
+          if (!isColorScheme(value)) {
             return;
           }
-          setTheme(value);
-          capture("theme_selected", { theme: value });
+          const preference = themePreferenceForScheme(value, systemScheme);
+          setTheme(preference);
+          capture("theme_selected", { theme: preference });
         }}
         className="cancelDrag"
       >
         <PillTabs.List size="compact" aria-label="Color theme">
           <PillTabs.Item value="light" aria-label="Light theme">
             <SunIcon aria-hidden />
-          </PillTabs.Item>
-          <PillTabs.Item value="system" aria-label="System theme">
-            <MonitorIcon aria-hidden />
           </PillTabs.Item>
           <PillTabs.Item value="dark" aria-label="Dark theme">
             <MoonIcon aria-hidden />

--- a/src/components/theme-preference.test.ts
+++ b/src/components/theme-preference.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  nextThemePreference,
+  themePreferenceForScheme,
+} from "./theme-preference";
+
+describe("themePreferenceForScheme", () => {
+  it("pins dark when OS is light", () => {
+    expect(themePreferenceForScheme("dark", "light")).toBe("dark");
+  });
+
+  it("returns system when picking light while OS is light", () => {
+    expect(themePreferenceForScheme("light", "light")).toBe("system");
+  });
+
+  it("pins light when OS is dark", () => {
+    expect(themePreferenceForScheme("light", "dark")).toBe("light");
+  });
+
+  it("returns system when picking dark while OS is dark", () => {
+    expect(themePreferenceForScheme("dark", "dark")).toBe("system");
+  });
+
+  it("keeps a dark pin expressible when OS later matches (pick light to leave)", () => {
+    // Stored dark, OS now dark: selecting light must pin light, not auto-clear.
+    expect(themePreferenceForScheme("light", "dark")).toBe("light");
+  });
+});
+
+describe("nextThemePreference", () => {
+  it("from system light, flip stores dark override", () => {
+    expect(nextThemePreference("light", "light")).toBe("dark");
+  });
+
+  it("from dark override with OS light, flip returns to system", () => {
+    expect(nextThemePreference("dark", "light")).toBe("system");
+  });
+
+  it("from system dark, flip stores light override", () => {
+    expect(nextThemePreference("dark", "dark")).toBe("light");
+  });
+
+  it("from light override with OS dark, flip returns to system", () => {
+    expect(nextThemePreference("light", "dark")).toBe("system");
+  });
+
+  it("from dark override that now matches OS dark, flip pins light", () => {
+    expect(nextThemePreference("dark", "dark")).toBe("light");
+  });
+});

--- a/src/components/theme-preference.ts
+++ b/src/components/theme-preference.ts
@@ -1,0 +1,19 @@
+export type ColorScheme = "light" | "dark";
+export type ThemePreference = ColorScheme | "system";
+
+/** Store system when the chosen scheme matches the OS; otherwise pin the scheme. */
+export function themePreferenceForScheme(
+  scheme: ColorScheme,
+  system: ColorScheme,
+): ThemePreference {
+  return scheme === system ? "system" : scheme;
+}
+
+/** Flip the resolved appearance, then apply Verou storage rules. */
+export function nextThemePreference(
+  resolved: ColorScheme,
+  system: ColorScheme,
+): ThemePreference {
+  const target: ColorScheme = resolved === "dark" ? "light" : "dark";
+  return themePreferenceForScheme(target, system);
+}


### PR DESCRIPTION
## Summary
- Replace the Light / System / Dark pills with sun and moon only, while keeping a three-value storage model.
- Selecting a scheme that matches the OS stores `system`; selecting the opposite pins `light` or `dark`.
- The `D` hotkey uses the same rule so system remains reachable after a flip.

## Test plan
- [x] Unit tests for `themePreferenceForScheme` / `nextThemePreference`
- [ ] Confirm the grid toggle shows two pills and the active one follows resolved appearance
- [ ] Flip to the opposite scheme and confirm localStorage stores `light` or `dark`
- [ ] Flip back to the OS-matching scheme and confirm localStorage stores `system`
- [ ] Press `D` and confirm it returns to system when the target matches the OS